### PR TITLE
Fix ruamel.yaml dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ dict2css>=0.2.3
 docutils==0.16
 domdf-python-tools>=2.9.0
 html5lib>=1.1
-ruamel-yaml>=0.16.12
+ruamel.yaml>=0.16.12
 sphinx<3.6.0,>=3.2.0
 sphinx-autodoc-typehints==1.11.1
 sphinx-prompt>=1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ dict2css>=0.2.3
 docutils==0.16
 domdf-python-tools>=2.9.0
 html5lib>=1.1
-ruamel.yaml>=0.16.12
+ruyaml>=0.16.12
 sphinx<3.6.0,>=3.2.0
 sphinx-autodoc-typehints==1.11.1
 sphinx-prompt>=1.1.0


### PR DESCRIPTION
The current dependency on ``ruamel.yaml`` causes an infinite loop when resolving dependencies using Poetry. ``ruyaml`` is a drop-in replacement.