### PR TITLE
Relax docutils requirement to >= 0.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ beautifulsoup4>=4.9.1
 cachecontrol[filecache]>=0.12.6
 deprecation-alias>=0.2.0
 dict2css>=0.2.3
-docutils==0.16
+docutils>=0.16
 domdf-python-tools>=2.9.0
 html5lib>=1.1
 lockfile>=0.12.2


### PR DESCRIPTION
Without this, I get conflicts...

```
The conflict is caused by:
    The user requested docutils==0.17.1
    sphinx 4.4.0 depends on docutils<0.18 and >=0.14
    sphinx-rtd-theme 1.0.0 depends on docutils<0.18
    doc8 0.8.1 depends on docutils
    restructuredtext-lint 1.3.2 depends on docutils<1.0 and >=0.11
    rstcheck 3.3.1 depends on docutils>=0.7
    snooty-lextudio 1.12.0 depends on docutils<0.18 and >=0.16
    sphinxcontrib-hdl-diagrams 0.0.post148 depends on docutils
    sphinx-toolbox 2.18.0 depends on docutils==0.16
```
