### PR TITLE
Parse issue titles with code

### DIFF
--- a/doc-source/changelog.rst
+++ b/doc-source/changelog.rst
@@ -3,6 +3,15 @@ Changelog
 ===============
 
 
+Unreleased
+--------------
+
+Bugs Fixed
+^^^^^^^^^^^
+
+* :mod:`sphinx_toolbox.github` now correctly parses issue titles containing code and quote characters. Reported by :github:user:`arisp99` in :github:issue:`91`.
+
+
 2.18.0
 --------------
 

--- a/sphinx_toolbox/github/issues.py
+++ b/sphinx_toolbox/github/issues.py
@@ -326,6 +326,8 @@ def get_issue_title(issue_url: str) -> Optional[str]:
 
 	if r.status_code == 200:
 		soup = BeautifulSoup(r.content, "html5lib")
-		return soup.find_all("span", attrs={"class": "js-issue-title"})[0].contents[0].strip().strip()
+		contents = soup.find_all("span", attrs={"class": "js-issue-title"})[0].contents
+		parsed = [c.get_text().strip() for c in contents]
+		return "".join(parsed)
 
 	return None

--- a/sphinx_toolbox/github/issues.py
+++ b/sphinx_toolbox/github/issues.py
@@ -328,6 +328,7 @@ def get_issue_title(issue_url: str) -> Optional[str]:
 	if r.status_code == 200:
 		soup = BeautifulSoup(r.content, "html5lib")
 		content = soup.find_all("span", attrs={"class": "js-issue-title"})[0].text
-		return xml.sax.saxutils.escape(content).replace('"', "&quot;")
+		content = xml.sax.saxutils.escape(content).replace('"', "&quot;")
+		return content.strip()
 
 	return None

--- a/sphinx_toolbox/github/issues.py
+++ b/sphinx_toolbox/github/issues.py
@@ -34,6 +34,7 @@ Roles and nodes for GitHub issues and Pull Requests.
 
 # stdlib
 import warnings
+import xml.sax.saxutils
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 # 3rd party
@@ -326,8 +327,7 @@ def get_issue_title(issue_url: str) -> Optional[str]:
 
 	if r.status_code == 200:
 		soup = BeautifulSoup(r.content, "html5lib")
-		contents = soup.find_all("span", attrs={"class": "js-issue-title"})[0].contents
-		parsed = [c.get_text().strip() for c in contents]
-		return ''.join(parsed)
+		content = soup.find_all("span", attrs={"class": "js-issue-title"})[0].text
+		return xml.sax.saxutils.escape(content).replace('"', "&quot;")
 
 	return None

--- a/sphinx_toolbox/github/issues.py
+++ b/sphinx_toolbox/github/issues.py
@@ -328,6 +328,6 @@ def get_issue_title(issue_url: str) -> Optional[str]:
 		soup = BeautifulSoup(r.content, "html5lib")
 		contents = soup.find_all("span", attrs={"class": "js-issue-title"})[0].contents
 		parsed = [c.get_text().strip() for c in contents]
-		return "".join(parsed)
+		return ''.join(parsed)
 
 	return None

--- a/tests/test_issues_output/github-issues-doc-test/test-github-issues-root/index.rst
+++ b/tests/test_issues_output/github-issues-doc-test/test-github-issues-root/index.rst
@@ -15,3 +15,9 @@ sphinx-toolbox Demo - GitHub Issues
 :source:`sphinx_toolbox/source.py`
 
 :source:`sphinx_toolbox/more_autodoc/__init__.py`
+
+Issue with code in its title: :github:issue:`10241 <sphinx-doc/sphinx>`.
+
+Issue with code in the beginning of the title: :github:issue:`9575 <sphinx-doc/sphinx>`.
+
+Issue with HTML entities in title: :github:issue:`56 <sphinx-toolbox/toctree_plus>`.

--- a/tests/test_issues_output/test_source_output.py
+++ b/tests/test_issues_output/test_source_output.py
@@ -24,7 +24,7 @@ def test_output_github(github_source_page: BeautifulSoup, html_regression: HTMLR
 	assert "sphinx-toolbox Demo - GitHub Issues" == title
 
 	links = github_source_page.select('p')
-	assert len(links) == 7
+	assert len(links) == 10
 
 	assert links[1] == links[2]
 
@@ -49,6 +49,16 @@ def test_output_github(github_source_page: BeautifulSoup, html_regression: HTMLR
 			'href="https://github.com/domdfcoding/sphinx-toolbox/blob/master/sphinx_toolbox/source.py">sphinx_toolbox/source.py</a></p>',
 			'<p><a class="reference external" '
 			'href="https://github.com/domdfcoding/sphinx-toolbox/blob/master/sphinx_toolbox/more_autodoc/__init__.py">sphinx_toolbox/more_autodoc/__init__.py</a></p>',
+			'<p>Issue with code in its title: <abbr title="Unable to install latest '
+			'version of flake8 and Sphinx together"><a class="reference external" '
+			'href="https://github.com/sphinx-doc/sphinx/issues/10241">sphinx-doc/sphinx#10241</a></abbr>.</p>',
+			'<p>Issue with code in the beginning of the title: <abbr '
+			'title=\'autodoc_typehints = "description" causes autoclass to put a return '
+			'type\'><a class="reference external" '
+			'href="https://github.com/sphinx-doc/sphinx/issues/9575">sphinx-doc/sphinx#9575</a></abbr>.</p>',
+			'<p>Issue with HTML entities in title: <abbr title="RFE: please provide '
+			'support for jinja2 &gt;= 3.1"><a class="reference external" '
+			'href="https://github.com/sphinx-toolbox/toctree_plus/issues/56">sphinx-toolbox/toctree_plus#56</a></abbr>.</p>',
 			]
 
 	html_regression.check(github_source_page)

--- a/tests/test_issues_output/test_source_output_/test_output_github_index_html_.html
+++ b/tests/test_issues_output/test_source_output_/test_output_github_index_html_.html
@@ -75,6 +75,33 @@
          sphinx_toolbox/more_autodoc/__init__.py
         </a>
        </p>
+       <p>
+        Issue with code in its title:
+        <abbr title="Unable to install latest version of flake8 and Sphinx together">
+         <a class="reference external" href="https://github.com/sphinx-doc/sphinx/issues/10241">
+          sphinx-doc/sphinx#10241
+         </a>
+        </abbr>
+        .
+       </p>
+       <p>
+        Issue with code in the beginning of the title:
+        <abbr title='autodoc_typehints = "description" causes autoclass to put a return type'>
+         <a class="reference external" href="https://github.com/sphinx-doc/sphinx/issues/9575">
+          sphinx-doc/sphinx#9575
+         </a>
+        </abbr>
+        .
+       </p>
+       <p>
+        Issue with HTML entities in title:
+        <abbr title="RFE: please provide support for jinja2 &gt;= 3.1">
+         <a class="reference external" href="https://github.com/sphinx-toolbox/toctree_plus/issues/56">
+          sphinx-toolbox/toctree_plus#56
+         </a>
+        </abbr>
+        .
+       </p>
       </div>
      </div>
     </div>


### PR DESCRIPTION
This quick fix should allow sphinx toolbox to parse issue titles with code in them. Tests were run successfully; however, I do not know how to add new tests.

Closes #91.