### PR TITLE
Impose sphinx-tabs<=3.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ sphinx>=3.2.0
 sphinx-autodoc-typehints>=1.11.1
 sphinx-jinja2-compat>=0.1.0
 sphinx-prompt>=1.1.0
-sphinx-tabs<3.4.0,>=1.2.1
+sphinx-tabs<3.5.0,>=1.2.1
 tabulate>=0.8.7
 typing-extensions!=3.10.0.1,>=3.7.4.3
 typing-inspect>=0.6.0; python_version < "3.8"


### PR DESCRIPTION
Resolves #114 by imposing:

```diff
-sphinx-tabs<3.4.0,>=1.2.1
+sphinx-tabs<3.5.0,>=1.2.1
```

Main advantage of `sphinx-tabs==3.4.0` is that its supports `Sphinx>=5.0`.