### PR TITLE
Fix duplicated fields/parameters in autonamedtuple and `autodoc_typehints = 'both'`

### DIFF
--- a/sphinx_toolbox/more_autodoc/autonamedtuple.py
+++ b/sphinx_toolbox/more_autodoc/autonamedtuple.py
@@ -419,6 +419,9 @@ class NamedTupleDocumenter(ClassDocumenter):
 
 		self.add_line('', sourcename)
 
+		# Stop a duplicate set of parameters being added with `autodoc_typehints = 'both'`
+		self.env.temp_data["annotations"] = {}
+
 		# Remove documenters corresponding to fields and return the rest
 		return [d for d in documenters if d[0].name.split('.')[-1] not in fields]
 

--- a/tests/test_output/doc-test/test-root/conf.py
+++ b/tests/test_output/doc-test/test-root/conf.py
@@ -69,3 +69,7 @@ def depart_desc_signature(self, node: addnodes.desc_signature) -> None:
 def setup(app: Sphinx) -> None:
 	app.connect("build-finished", latex.replace_unknown_unicode)
 	app.add_node(addnodes.desc_signature, html=(visit_desc_signature, depart_desc_signature), override=True)
+
+
+# TODO: add test matrix with this option enabled
+# autodoc_typehints = "both"


### PR DESCRIPTION
Fixes #121 