### PR TITLE
Use docutils-style attribute in CollapseNode

### DIFF
--- a/sphinx_toolbox/collapse.py
+++ b/sphinx_toolbox/collapse.py
@@ -175,7 +175,7 @@ def visit_collapse_node(translator: HTML5Translator, node: CollapseNode) -> None
 	if node.attributes.get("open", False):
 		tag_parts.append("open")
 
-	translator.body.append(f"<{tag_parts: }>\n<summary>{node["label"]}</summary>")
+	translator.body.append(f"<{tag_parts: }>\n<summary>{node['label']}</summary>")
 	translator.context.append("</details>")
 
 

--- a/sphinx_toolbox/collapse.py
+++ b/sphinx_toolbox/collapse.py
@@ -151,7 +151,7 @@ class CollapseNode(nodes.Body, nodes.Element):
 
 	def __init__(self, rawsource: str = '', label: Optional[str] = None, *children, **attributes):
 		super().__init__(rawsource, *children, **attributes)
-		self.label = label
+		self["label"] = label
 
 
 def visit_collapse_node(translator: HTML5Translator, node: CollapseNode) -> None:
@@ -175,7 +175,7 @@ def visit_collapse_node(translator: HTML5Translator, node: CollapseNode) -> None
 	if node.attributes.get("open", False):
 		tag_parts.append("open")
 
-	translator.body.append(f"<{tag_parts: }>\n<summary>{node.label}</summary>")
+	translator.body.append(f"<{tag_parts: }>\n<summary>{node["label"]}</summary>")
 	translator.context.append("</details>")
 
 


### PR DESCRIPTION
I came across an issue when trying to build a Sphinx project including the sphinx-toolbox extension using the singlehtml builder.
```
File "/pathtomyproj/.venv/lib/python3.10/site-packages/sphinx_toolbox/collapse.py", line 178, in visit_collapse_node
    translator.body.append(f"<{tag_parts: }>\n<summary>{node.label}</summary>")
AttributeError: 'CollapseNode' object has no attribute 'label'
```
I recognized this issue, as I had similar problems a while ago with one of my own extensions.
My assumption is, that the label attribute of the collapse node is lost at some point, when the doctrees are being deepcopied.
As far as I remember, this has something to do with how the objects are being copied based on their type.

Anyways, changing the "label" attribute from the classic python-style to the docutils-style (as described in the api documentation of `docutils.nodes.Elements` [here](https://docutils.sourceforge.io/docutils/nodes.py#:~:text=Elements%20emulate%20dictionaries%20for%20external%20%5B%23%5D_%20attributes%2C%20indexing%20by%0A%20%20%20%20attribute%20name%20(a%20string).%20To%20set%20the%20attribute%20%27att%27%20to%20%27value%27%2C%20do%3A%3A%0A%0A%20%20%20%20%20%20%20%20element%5B%27att%27%5D%20%3D%20%27value%27)) fixed the issue for me.