### PR TITLE
Permit sphinx-tabs 3.4.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ sphinx>=3.2.0
 sphinx-autodoc-typehints>=1.11.1
 sphinx-jinja2-compat>=0.1.0
 sphinx-prompt>=1.1.0
-sphinx-tabs<3.4.7,>=1.2.1
+sphinx-tabs<3.4.8,>=1.2.1
 tabulate>=0.8.7
 typing-extensions!=3.10.0.1,>=3.7.4.3
 typing-inspect>=0.6.0; python_version < "3.8"


### PR DESCRIPTION
The only difference between
3.4.6 and 3.4.7 is a change
in the CI so the release
got automatically uploaded
to PyPi.

This makes default Dependabot
updates work again.

Fixes #189