### PR TITLE
Update sphinx-autodoc-typehints imports to work with >=3.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,10 @@ incremental = false
 exclude = "^tests/.*?/[^/]*doc-test/.*"
 show_error_codes = true
 
+[[tool.mypy.overrides]]
+module = [ "sphinx_autodoc_typehints._annotations", "sphinx_autodoc_typehints._resolver.*",]
+ignore_missing_imports = true
+
 [tool.snippet-fmt]
 directives = [ "code-block",]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ html5lib>=1.1
 roman>4.0
 ruamel.yaml<=0.18.16,>=0.16.12
 sphinx>=3.2.0
-sphinx-autodoc-typehints<3.6.0,>=1.11.1
+sphinx-autodoc-typehints<3.6.0,>=1.13.0
 sphinx-jinja2-compat>=0.1.0
 sphinx-prompt>=1.1.0
 sphinx-tabs<3.6.0,>=3.4.7

--- a/sphinx_toolbox/more_autodoc/typehints.py
+++ b/sphinx_toolbox/more_autodoc/typehints.py
@@ -172,23 +172,30 @@ except ImportError:  # pragma: no cover
 	# where it is available to import, so it is fine to do this.
 	pass
 
-try:
+if sphinx_autodoc_typehints.version.version_tuple >= (3, 8):
 	# 3rd party
-	from sphinx_autodoc_typehints import logger as sat_logger  # type: ignore[attr-defined]
-	from sphinx_autodoc_typehints import pydata_annotations  # type: ignore[attr-defined]
-except ImportError:
+	from sphinx_autodoc_typehints import _LOGGER as sat_logger
+	from sphinx_autodoc_typehints._annotations import _PYDATA_ANNOTATIONS as pydata_annotations
+elif sphinx_autodoc_typehints.version.version_tuple >= (1, 14, 1):
 	# Privatised in 1.14.1
 	# 3rd party
 	from sphinx_autodoc_typehints import _LOGGER as sat_logger
 	from sphinx_autodoc_typehints import _PYDATA_ANNOTATIONS as pydata_annotations
+else:
+	# 3rd party
+	from sphinx_autodoc_typehints import logger as sat_logger  # type: ignore[attr-defined,no-redef]
+	from sphinx_autodoc_typehints import pydata_annotations  # type: ignore[attr-defined]
 
 if isinstance(next(iter(pydata_annotations)), tuple):
 	pydata_annotations = {x[1] for x in pydata_annotations}
 
-try:
+if sphinx_autodoc_typehints.version.version_tuple >= (3, 8):
+	# 3rd party
+	from sphinx_autodoc_typehints._resolver._type_hints import _future_annotations_imported
+elif sphinx_autodoc_typehints.version.version_tuple >= (1, 14, 0):
 	# 3rd party
 	from sphinx_autodoc_typehints import _future_annotations_imported
-except ImportError:
+else:
 
 	def _future_annotations_imported(obj: Any) -> bool:
 		if sys.version_info < (3, 7):  # pragma: no cover (py37+)
@@ -230,8 +237,13 @@ get_annotation_module = sphinx_autodoc_typehints.get_annotation_module
 get_annotation_class_name = sphinx_autodoc_typehints.get_annotation_class_name
 get_annotation_args = sphinx_autodoc_typehints.get_annotation_args
 backfill_type_hints = sphinx_autodoc_typehints.backfill_type_hints
-load_args = sphinx_autodoc_typehints.load_args
-split_type_comment_args = sphinx_autodoc_typehints.split_type_comment_args
+if sphinx_autodoc_typehints.version.version_tuple >= (3, 8):
+	# 3rd party
+	from sphinx_autodoc_typehints._resolver._type_comments import _load_args as load_args
+	from sphinx_autodoc_typehints._resolver._type_comments import _split_type_comment_args as split_type_comment_args
+else:
+	load_args = sphinx_autodoc_typehints.load_args
+	split_type_comment_args = sphinx_autodoc_typehints.split_type_comment_args
 
 
 # Demonstration of module default argument in signature


### PR DESCRIPTION
sphinx-autodoc-typehints moved some stuff from `__init__.py` to submodules in tox-dev/sphinx-autodoc-typehints@9f630991b238ea6c9bb950b5f4b2198170b0c690, and then split `_resolver.py` into more granular modules in tox-dev/sphinx-autodoc-typehints@98428ebc045c697935da486d7e75694edf9bad17.

And bump required version to >=1.13.0 (from 2022-01-01), where `version_tuple` was introduced.

I ran the tests with all boundary versions, and they pass.