### PR TITLE
Support inline markup in collapse labels

### DIFF
--- a/sphinx_toolbox/collapse.py
+++ b/sphinx_toolbox/collapse.py
@@ -42,6 +42,10 @@ Usage
 
 				print("Not really")
 
+		.. collapse:: The **label** also supports *inline* ``markup``!
+
+			Markdown is also supported if using MyST.
+
 
 	.. rst:directive:option:: open
 		:type: flag

--- a/sphinx_toolbox/collapse.py
+++ b/sphinx_toolbox/collapse.py
@@ -175,8 +175,13 @@ def depart_collapse_summary_node(translator: HTML5Translator, node: CollapseSumm
 	translator.body.append("</summary>")
 
 
-def visit_collapse_summary_node_non_html(*args, **kwargs) -> None:
-	"""Skip the collapse summary for non-HTML builders."""
+def visit_collapse_summary_node_non_html(*_, **__) -> None:
+	r"""
+	Skip the collapse summary for non-HTML builders.
+
+	:param \*_: Positional arguments; ignored.
+	:param \*\*__: Keyword arguments; ignored.
+	"""
 
 	raise nodes.SkipNode
 

--- a/sphinx_toolbox/collapse.py
+++ b/sphinx_toolbox/collapse.py
@@ -19,6 +19,8 @@ Usage
 
 	.. _details: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details
 
+	The label supports the complete inline markup syntax of the active source parser.
+
 	With non-HTML builders, the content will be added as-is.
 
 	.. rest-example::
@@ -83,6 +85,7 @@ API Reference
 #
 
 # stdlib
+from html import escape
 from typing import Optional, Sequence
 
 # 3rd party
@@ -128,17 +131,53 @@ class CollapseDirective(SphinxDirective):
 
 		text = '\n'.join(self.content)
 		label = self.arguments[0]
+		inline_nodes, messages = self.state.inline_text(label, self.lineno)
+		summary_node = CollapseSummaryNode(label, '', *inline_nodes)
+		self.set_source_info(summary_node)
 
 		collapse_node = CollapseNode(text, label, **self.options)
 
 		self.add_name(collapse_node)
 
-		collapse_node["classes"].append(f"summary-{nodes.make_id(label)}")
+		collapse_node["classes"].append(f"summary-{nodes.make_id(summary_node.astext())}")
 
+		collapse_node.append(summary_node)
 		self.state.nested_parse(self.content, self.content_offset, collapse_node)
 
-		return [collapse_node]
+		return [collapse_node, *messages]
 
+
+class CollapseSummaryNode(nodes.TextElement, nodes.General):
+	"""
+	Node that represents the summary of a collapsible section.
+	"""
+
+def visit_collapse_summary_node(translator: HTML5Translator, node: CollapseSummaryNode) -> None:
+	"""
+	Visit a :class:`~.CollapseSummaryNode`.
+
+	:param translator:
+	:param node: The node being visited.
+	"""
+
+	translator.body.append("<summary>")
+
+
+def depart_collapse_summary_node(translator: HTML5Translator, node: CollapseSummaryNode) -> None:
+	"""
+	Depart a :class:`~.CollapseSummaryNode`.
+
+	:param translator:
+	:param node: The node being visited.
+	"""
+
+	translator.body.append("</summary>")
+
+
+def visit_collapse_summary_node_non_html(*args, **kwargs) -> None:
+	"""Skip the collapse summary for non-HTML builders."""
+
+	raise nodes.SkipNode
 
 class CollapseNode(nodes.Body, nodes.Element):  # noqa: PRM002
 	"""
@@ -174,7 +213,9 @@ def visit_collapse_node(translator: HTML5Translator, node: CollapseNode) -> None
 	if node.attributes.get("open", False):
 		tag_parts.append("open")
 
-	translator.body.append(f"<{tag_parts: }>\n<summary>{node['label']}</summary>")
+	translator.body.append(f"<{tag_parts: }>\n")
+	if not any(isinstance(child, CollapseSummaryNode) for child in node.children):
+		translator.body.append(f"<summary>{escape(node.get('label') or '')}</summary>")
 	translator.context.append("</details>")
 
 
@@ -203,6 +244,12 @@ def setup(app: Sphinx) -> SphinxExtMetadata:
 			html=(visit_collapse_node, depart_collapse_node),
 			latex=(lambda *args, **kwargs: None, lambda *args, **kwargs: None),
 			man=(lambda *args, **kwargs: None, lambda *args, **kwargs: None),
+			)
+	app.add_node(
+			CollapseSummaryNode,
+			html=(visit_collapse_summary_node, depart_collapse_summary_node),
+			latex=(visit_collapse_summary_node_non_html, lambda *args, **kwargs: None),
+			man=(visit_collapse_summary_node_non_html, lambda *args, **kwargs: None),
 			)
 
 	return {

--- a/sphinx_toolbox/collapse.py
+++ b/sphinx_toolbox/collapse.py
@@ -152,6 +152,7 @@ class CollapseSummaryNode(nodes.TextElement, nodes.General):
 	Node that represents the summary of a collapsible section.
 	"""
 
+
 def visit_collapse_summary_node(translator: HTML5Translator, node: CollapseSummaryNode) -> None:
 	"""
 	Visit a :class:`~.CollapseSummaryNode`.
@@ -178,6 +179,7 @@ def visit_collapse_summary_node_non_html(*args, **kwargs) -> None:
 	"""Skip the collapse summary for non-HTML builders."""
 
 	raise nodes.SkipNode
+
 
 class CollapseNode(nodes.Body, nodes.Element):  # noqa: PRM002
 	"""

--- a/tests/test_output/doc-test/test-root/collapse.rst
+++ b/tests/test_output/doc-test/test-root/collapse.rst
@@ -1,5 +1,7 @@
 :orphan:
 
+.. _collapse-heading:
+
 =========
 Collapse
 =========
@@ -20,3 +22,7 @@ Collapse
 	:open:
 
 	The text should be visible when the page loads.
+
+.. collapse:: **Strong** and *emphasis*, ``literal``, |hello|, and :ref:`a reference <collapse-heading>`
+
+	The label supports inline markup.

--- a/tests/test_output/test_output_/test_html_output_collapse_html_.html
+++ b/tests/test_output/test_output_/test_html_output_collapse_html_.html
@@ -34,6 +34,8 @@
     <div class="bodywrapper">
      <div class="body" role="main">
       <div class="section" id="collapse">
+       <span id="collapse-heading">
+       </span>
        <h1>
         Collapse
         <a class="headerlink" href="#collapse" title="{{ permalink }} to this {{ heading }}">
@@ -62,6 +64,32 @@
         </summary>
         <p>
          The text should be visible when the page loads.
+        </p>
+       </details>
+       <details class="summary-strong-and-emphasis-literal-hello-and-a-reference">
+        <summary>
+         <strong>
+          Strong
+         </strong>
+         and
+         <em>
+          emphasis
+         </em>
+         ,
+         <code class="docutils literal notranslate">
+          <span class="pre">
+           literal
+          </span>
+         </code>
+         , world, and
+         <a class="reference internal" href="#collapse-heading">
+          <span class="std std-ref">
+           a reference
+          </span>
+         </a>
+        </summary>
+        <p>
+         The label supports inline markup.
         </p>
        </details>
       </div>{% if sphinx_version >= (8, 1) %}

--- a/tests/test_output/test_output_/test_latex_output.tex
+++ b/tests/test_output/test_output_/test_latex_output.tex
@@ -507,12 +507,14 @@ to the \sphinxcode{\sphinxupquote{extensions}} variable in your \sphinxcode{\sph
 <% endif %>
 
 \chapter{Collapse}
-\label{\detokenize{collapse:collapse}}\label{\detokenize{collapse::doc}}
+\label{\detokenize{collapse:collapse}}\label{\detokenize{collapse:collapse-heading}}\label{\detokenize{collapse::doc}}
 Something small enough to escape casual notice.
 
 Something else that might escape notice.
 
 The text should be visible when the page loads.
+
+The label supports inline markup.
 <% if sphinx_version > (4, 5) %>
 \sphinxstepscope
 <% endif %>

--- a/tests/test_output/test_output_/test_latex_output_autosummary_col_type.tex
+++ b/tests/test_output/test_output_/test_latex_output_autosummary_col_type.tex
@@ -507,12 +507,14 @@ to the \sphinxcode{\sphinxupquote{extensions}} variable in your \sphinxcode{\sph
 <% endif %>
 
 \chapter{Collapse}
-\label{\detokenize{collapse:collapse}}\label{\detokenize{collapse::doc}}
+\label{\detokenize{collapse:collapse}}\label{\detokenize{collapse:collapse-heading}}\label{\detokenize{collapse::doc}}
 Something small enough to escape casual notice.
 
 Something else that might escape notice.
 
 The text should be visible when the page loads.
+
+The label supports inline markup.
 <% if sphinx_version > (4, 5) %>
 \sphinxstepscope
 <% endif %>

--- a/tests/test_output/test_output_/test_latex_output_better_header_layout.tex
+++ b/tests/test_output/test_output_/test_latex_output_better_header_layout.tex
@@ -531,12 +531,14 @@ to the \sphinxcode{\sphinxupquote{extensions}} variable in your \sphinxcode{\sph
 <% endif %>
 
 \chapter{Collapse}
-\label{\detokenize{collapse:collapse}}\label{\detokenize{collapse::doc}}
+\label{\detokenize{collapse:collapse}}\label{\detokenize{collapse:collapse-heading}}\label{\detokenize{collapse::doc}}
 Something small enough to escape casual notice.
 
 Something else that might escape notice.
 
 The text should be visible when the page loads.
+
+The label supports inline markup.
 <% if sphinx_version > (4, 5) %>
 \sphinxstepscope
 <% endif %>

--- a/tests/test_output/test_output_/test_latex_output_latex_layout.tex
+++ b/tests/test_output/test_output_/test_latex_output_latex_layout.tex
@@ -507,12 +507,14 @@ to the \sphinxcode{\sphinxupquote{extensions}} variable in your \sphinxcode{\sph
 <% endif %>
 
 \chapter{Collapse}
-\label{\detokenize{collapse:collapse}}\label{\detokenize{collapse::doc}}
+\label{\detokenize{collapse:collapse}}\label{\detokenize{collapse:collapse-heading}}\label{\detokenize{collapse::doc}}
 Something small enough to escape casual notice.
 
 Something else that might escape notice.
 
 The text should be visible when the page loads.
+
+The label supports inline markup.
 <% if sphinx_version > (4, 5) %>
 \sphinxstepscope
 <% endif %>


### PR DESCRIPTION
Introduce a `CollapseSummaryNode` so labels support the active parser’s (reST, MyST, ...) inline markup, including emphasis, literals, substitutions, links, and roles. Preserve body-only output for non-HTML builders and compatibility with legacy collapse nodes.

Closes #141 